### PR TITLE
Expressive test case names.

### DIFF
--- a/lib/clerk.rb
+++ b/lib/clerk.rb
@@ -55,6 +55,7 @@ class Clerk
     slice_size = value_keys.length
     groups = Array.new
     values.each_slice(slice_size).each do |group|
+      group = group + [nil] * (value_keys.length - group.length) if group.length < value_keys.length
       keyed_group = Hash.new
       group.each_with_index do |value, index|
         keyed_group[value_keys[index]] = value

--- a/test/test_clerk.rb
+++ b/test/test_clerk.rb
@@ -2,7 +2,7 @@ require 'test/unit'
 require 'clerk'
 
 class ClerkTest < Test::Unit::TestCase
-  def test_template_requirement 
+  def test_template_required_to_process_data
     c = Clerk.new
     assert_raise RuntimeError do
       c.process %w(test data)
@@ -13,27 +13,37 @@ class ClerkTest < Test::Unit::TestCase
     end
   end
 
-  def test_named 
+  def test_elements_matched_with_named_template_position 
     template = [:a]
     csv = %w(test)
     res = {:a => 'test'} 
     assert_transformation template, csv, res
   end
 
-  def test_ignored
+  def test_element_ignored_when_corresponding_nil_in_template
     template = [:a, nil, :b]
     csv = %w(test ignore not)
     res = {:a => 'test', :b => 'not'} 
     assert_transformation template, csv, res
   end
 
-  def test_grouping 
+  def test_elements_grouped_per_template
     template = [{:group => [:a, :b]}]
     csv = %w(a b c d e f)
     res = {:group => [
       {:a => 'a', :b => 'b'},
       {:a => 'c', :b => 'd'},
       {:a => 'e', :b => 'f'}]}
+    assert_transformation template, csv, res
+  end
+
+  def test_grouping_uneven_number_of_elements_fils_with_nil
+    template = [{:group => [:a, :b, :c]}]
+    csv = %w(a b c d e f g)
+    res = {:group => [
+      {:a => 'a', :b => 'b', :c => 'c'},
+      {:a => 'd', :b => 'e', :c => 'f'},
+      {:a => 'g', :b => nil, :c => nil}]}
     assert_transformation template, csv, res
   end
 
@@ -48,7 +58,7 @@ class ClerkTest < Test::Unit::TestCase
     assert_transformation template, csv, res
   end
 
-  def test_string_input
+  def test_string_input_parsed_as_csv_input
     template = [:a, nil, :b]
     csv = 'test,ignored,value'
     res = {:a => 'test', :b => 'value'}


### PR DESCRIPTION
Adding more expressive names to the test cases to, hopefully,
better indicate the behavior of the Clerk processor.

I also added a test case to verify behavior when the number of elements in the input data is not a multiple of the number of elements in the grouping template.
