### PR TITLE
Fixes #13 Support missing grouped data

### DIFF
--- a/lib/clerk/base.rb
+++ b/lib/clerk/base.rb
@@ -107,9 +107,13 @@ module Clerk
         grouped_data = data.select { |key, value| value.kind_of? Array }
         grouped_data.keys.each { |key| data.delete(key) }
         grouped_data.each do |key, values|
-          values.each do |value|
-            group = Hash[key, value]
-            sets.push self.class._result_set_klass.new(data.merge(group))
+          if values.empty?
+            sets.push self.class._result_set_klass.new(data.merge(Hash[key, []]))
+          else
+            values.each do |value|
+              group = Hash[key, value]
+              sets.push self.class._result_set_klass.new(data.merge(group))
+            end
           end
         end
       else

--- a/test/test_clerk.rb
+++ b/test/test_clerk.rb
@@ -84,4 +84,49 @@ class ClerkTest < Test::Unit::TestCase
 
     assert_equal expected, clerk.results
   end
+
+  def test_clerk_handles_no_group_data_when_group_defined
+    klass = Class.new Clerk::Base
+    klass.template do |t|
+      t.ignored
+      t.named :name
+      t.named :race
+      t.named :gender
+      t.named :class
+      t.ignored
+      t.grouped(:loot) do |g|
+        g.named :name
+        g.named :quantity
+      end
+    end
+
+    data = [
+      "1,Fhaemita Dewshining,Half-elf,Female,3,80".split(","),
+      "2,George,Full-elf,Male,2,20,Gold,100,Rubies,20".split(",")
+    ]
+
+    clerk = klass.new
+    clerk.load data
+
+    expected = [{
+        :name   => "Fhaemita Dewshining",
+        :race   => "Half-elf",
+        :gender => "Female",
+        :class  => "3",
+        :loot   => []
+      },
+      {
+        :name => "George",
+        :race => "Full-elf",
+        :gender => "Male",
+        :class=> "2", 
+        :loot => [
+          {:name => "Gold", :quantity => "100"},
+          {:name => "Rubies",:quantity => "20" }
+        ]
+      }
+    ]
+
+    assert_equal expected, clerk.results
+  end
 end


### PR DESCRIPTION
When data is supposed to be grouped according to the template but
is missing from the input data, the results were not being returned
correctly. This commit fixes that problem by checking to see if
the data is not there already and properly handling that case.
