### PR TITLE
Resolves #14 Ignore multiple columns

### DIFF
--- a/lib/clerk/template.rb
+++ b/lib/clerk/template.rb
@@ -146,13 +146,17 @@ module Clerk
     # discarded on transformation, the ignored directive should be
     # used to ignore it in the resulting structure.
     #
+    # * *Args* :
+    #   - +num+ -> Number of columns to ignore [default = 1]
     # * *Returns* :
     #   - current template array
     # * *Raises* :
     #   - +Clerk::GroupedNotLastError+ -> if there is a grouped element in the template
-    def ignored
+    #   - +ArgumentError+ -> if number of columns is less than one
+    def ignored(num = 1)
       raise GroupedNotLastError if has_grouped_element?
-      @template_array << nil
+      raise ArgumentError if num < 1
+      @template_array.concat(Array.new(num))
     end
 
     ##

--- a/test/clerk/test_clerk_template.rb
+++ b/test/clerk/test_clerk_template.rb
@@ -61,6 +61,17 @@ class ClerkTemplateTest < Test::Unit::TestCase
     assert_equal [nil], @template.to_a
   end
 
+  def test_ignore_multiple_columns
+    @template.ignored 3
+    assert_equal [nil, nil, nil], @template.to_a
+  end
+
+  def test_ignore_requires_num_greater_than_zero
+    assert_raise ArgumentError do
+      @template.ignored 0
+    end
+  end
+
   def test_grouped_creates_template_group
     @template.grouped(:group_name) do |group|
       group.named :a


### PR DESCRIPTION
This commit allows Clerks to ignore multiple columns in a row by
passing a parameter to the `template.ignored` DSL method.
