### PR TITLE
Fixes a bug in which only the first error message is returned

### DIFF
--- a/lib/clerk/base.rb
+++ b/lib/clerk/base.rb
@@ -76,9 +76,13 @@ module Clerk
     #
     # Returns Boolean representing valid (true) or invalid (false)
     def valid?(*args)
-      @transformed_values.all? do |sets| 
-        sets.all? { |set| set.valid? } 
+      valid = true
+      @transformed_values.each do |sets| 
+        sets.each do |set| 
+          valid = false unless set.valid?
+        end
       end
+      valid
     end
 
     # Public: Retrieve validation error messages

--- a/test/clerk/test_clerk_validation.rb
+++ b/test/clerk/test_clerk_validation.rb
@@ -81,4 +81,23 @@ class ClerkValidationTest < Test::Unit::TestCase
     assert clerk.invalid?
   end
 
+  def test_validation_of_multiple_errors_in_a_set
+    klass = Class.new(Clerk::Base) 
+    klass.template do |t| 
+      t.named 'a'
+      t.grouped :group_name do |group|
+        group.named 'ga'
+        group.named :gb
+      end
+    end
+
+    klass.validates_presence_of 'a'
+    klass.validates_presence_of :'group_name/ga'
+
+    clerk = klass.new
+    clerk.load [%W(A #{} GB), %W(#{} GA GB)]
+    assert clerk.invalid?
+    assert_equal 2, clerk.errors.size 
+  end
+
 end


### PR DESCRIPTION
This fixes an issue where only one error messages was returned from `clerk.errors`.  After looking at the implementation I realized that `.all?` was the culprit; it'll short circuit on the first failure.

@jcarouth Can you look this over and give it a spin?
