### PR TITLE
[#116390481] Upgrade to Rails 4.0.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 gemspec
 
+gem 'test-unit'
 gem 'simplecov'

--- a/clerk-gem.gemspec
+++ b/clerk-gem.gemspec
@@ -1,11 +1,11 @@
 Gem::Specification.new do |s|
   s.name        = 'clerk-gem'
-  s.version     = '0.1.0'
-  s.date        = '2013-05-29'
-  s.authors     = ['Sean Callan', 'Jeff Carouth']
-  s.email       = ['callan@liftopia.com', 'jeff@liftopia.com']
+  s.version     = '0.2.0'
+  s.date        = '2016-04-01'
+  s.authors     = ['Liftopia Engineering']
+  s.email       = ['info@liftopia.com']
   s.summary     = 'Clerk helps turn data into a structured, verified, and transformed collection.'
   s.license     = 'MIT'
   s.files       = ['lib/clerk.rb']
-  s.add_dependency('activemodel', '~> 3.2.13')
+  s.add_dependency('activemodel', '>= 4.0.13')
 end


### PR DESCRIPTION
Bumping the clerk dependency version from the ActiveModel 3.2 line to 

> = 4.0.13 in order to support the Rails 4 upgrade of rtopia.

RFC @jakefolio 
